### PR TITLE
Test refactor prototype/transforms

### DIFF
--- a/torchvision/prototype/transforms/_geometry.py
+++ b/torchvision/prototype/transforms/_geometry.py
@@ -13,26 +13,14 @@ from torchvision.transforms.transforms import _setup_size, _interpolation_modes_
 from typing_extensions import Literal
 
 from ._transform import _RandomApplyTransform
-from ._utils import query_image, get_image_dimensions, has_any, is_simple_tensor
+from ._utils import query_image, get_image_dimensions, has_any, is_simple_tensor, get_class_func, noops, output_new_like
 
 
 class RandomHorizontalFlip(_RandomApplyTransform):
     def _transform(self, input: Any, params: Dict[str, Any]) -> Any:
-        if isinstance(input, features.Image):
-            output = F.horizontal_flip_image_tensor(input)
-            return features.Image.new_like(input, output)
-        elif isinstance(input, features.SegmentationMask):
-            output = F.horizontal_flip_segmentation_mask(input)
-            return features.SegmentationMask.new_like(input, output)
-        elif isinstance(input, features.BoundingBox):
-            output = F.horizontal_flip_bounding_box(input, format=input.format, image_size=input.image_size)
-            return features.BoundingBox.new_like(input, output)
-        elif isinstance(input, PIL.Image.Image):
-            return F.horizontal_flip_image_pil(input)
-        elif is_simple_tensor(input):
-            return F.horizontal_flip_image_tensor(input)
-        else:
-            return input
+        fn = get_class_func(input).getattr("horizontal_flip", noops)
+        output = fn(input)
+        return output_new_like(input, output)
 
 
 class RandomVerticalFlip(_RandomApplyTransform):

--- a/torchvision/prototype/transforms/_utils.py
+++ b/torchvision/prototype/transforms/_utils.py
@@ -6,6 +6,8 @@ from torchvision.prototype import features
 from torchvision.prototype.utils._internal import query_recursively
 
 from .functional._meta import get_dimensions_image_tensor, get_dimensions_image_pil
+from torchvision.prototype.transforms.functional import ImageTensorFunc, ImagePILFunc, SegmentationMaskFunc, BoundingBoxFunc
+from torchvision.prototype import features
 
 
 def query_image(sample: Any) -> Union[PIL.Image.Image, torch.Tensor, features.Image]:
@@ -50,3 +52,33 @@ def has_all(sample: Any, *types: Type) -> bool:
 
 def is_simple_tensor(input: Any) -> bool:
     return isinstance(input, torch.Tensor) and not isinstance(input, features._Feature)
+
+
+def get_class_func(input):
+    if isinstance(input, features.Image):
+        return ImageTensorFunc
+    elif isinstance(input, features.SegmentationMask):
+        return SegmentationMaskFunc
+    elif isinstance(input, features.BoundingBox):
+        return BoundingBoxFunc
+    elif is_simple_tensor(input):
+        return ImageTensorFunc
+    elif isinstance(input, PIL.Image.Image):
+        return ImagePILFunc
+    else:
+        raise TypeError("The input type is not valid!")
+
+
+def noops(x):
+    return x
+
+
+def output_new_like(input, output):
+    if isinstance(input, features.Image):
+        return features.Image.new_like(input, output)
+    elif isinstance(input, features.BoundingBox):
+        return features.BoundingBox.new_like(input, output)
+    elif isinstance(input, features.SegmentationMask):
+        return features.SegmentationMask.new_like(input, output)
+    else:
+        return output

--- a/torchvision/prototype/transforms/functional/__init__.py
+++ b/torchvision/prototype/transforms/functional/__init__.py
@@ -82,3 +82,25 @@ from ._type_conversion import (
     to_image_tensor,
     to_image_pil,
 )
+
+
+class ImageTensorFunc:
+    horizontal_flip = horizontal_flip_image_tensor
+    center_crop = center_crop_image_tensor
+    pad = pad_image_tensor
+
+
+
+class ImagePILFunc:
+    horizontal_flip = horizontal_flip_image_pil
+    center_crop = center_crop_image_pil
+    pad = pad_image_pil
+
+
+class SegmentationMaskFunc:
+    horizontal_flip = horizontal_flip_segmentation_mask
+
+
+class BoundingBoxFunc:
+    horizontal_flip = horizontal_flip_bounding_box
+    pad = pad_bounding_box


### PR DESCRIPTION
I have an idea on how to refactor prototype/transforms to reduce the amount of "if - else" depend on the type for each transform. The concept is to bundle the low level kernel together as a static method of a class, then we have utils function to return the correct class that have the function depend on the input type.

This PR just meant for visualizing the idea and concept, it is not meant to be merged.

Note: just to be safe, the base of the PR also a test-base branch.