### PR TITLE
[DONT MERGE] Getting video accuracy of Omnivore model

### DIFF
--- a/references/video_classification/train.py
+++ b/references/video_classification/train.py
@@ -154,6 +154,7 @@ def main(args):
     valdir = os.path.join(args.data_path, "val")
 
     print("Loading training data")
+    """
     st = time.time()
     cache_path = _get_cache_path(traindir, args)
     transform_train = presets.VideoClassificationPresetTrain(crop_size=(112, 112), resize_size=(128, 171))
@@ -185,6 +186,7 @@ def main(args):
             utils.save_on_master((dataset, traindir), cache_path)
 
     print("Took", time.time() - st)
+    """
 
     print("Loading validation data")
     cache_path = _get_cache_path(valdir, args)
@@ -215,6 +217,7 @@ def main(args):
                 "mp4",
             ),
             output_format="TCHW",
+            num_workers=args.workers,
         )
         if args.cache_dataset:
             print(f"Saving dataset_test to {cache_path}")
@@ -222,12 +225,13 @@ def main(args):
             utils.save_on_master((dataset_test, valdir), cache_path)
 
     print("Creating data loaders")
-    train_sampler = RandomClipSampler(dataset.video_clips, args.clips_per_video)
+    # train_sampler = RandomClipSampler(dataset.video_clips, args.clips_per_video)
     test_sampler = UniformClipSampler(dataset_test.video_clips, args.clips_per_video)
     if args.distributed:
-        train_sampler = DistributedSampler(train_sampler)
+        # train_sampler = DistributedSampler(train_sampler)
         test_sampler = DistributedSampler(test_sampler, shuffle=False)
 
+    """
     data_loader = torch.utils.data.DataLoader(
         dataset,
         batch_size=args.batch_size,
@@ -236,6 +240,7 @@ def main(args):
         pin_memory=True,
         collate_fn=collate_fn,
     )
+    """
 
     data_loader_test = torch.utils.data.DataLoader(
         dataset_test,
@@ -260,6 +265,7 @@ def main(args):
 
     # convert scheduler to be per iteration, not per epoch, for warmup that lasts
     # between different epochs
+    """
     iters_per_epoch = len(data_loader)
     lr_milestones = [iters_per_epoch * (m - args.lr_warmup_epochs) for m in args.lr_milestones]
     main_lr_scheduler = torch.optim.lr_scheduler.MultiStepLR(optimizer, milestones=lr_milestones, gamma=args.lr_gamma)
@@ -285,7 +291,8 @@ def main(args):
         )
     else:
         lr_scheduler = main_lr_scheduler
-
+    
+    """
     model_without_ddp = model
     if args.distributed:
         model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[args.gpu])


### PR DESCRIPTION
To run the validation script in this PR, we require to install torchmultimodal on this branch: https://github.com/YosuaMichael/multimodal/tree/omnivore/add-more-variant-and-weight

This PR is based on https://github.com/pytorch/vision/pull/6241 , but we comment out lines that generate training data and other line that depend on it (to make the run faster).

For all the experiment below, we use kinetics-400 dataset with some video excluded (because they can't be decoded by either pyav or torchvision backend). Here is the list of excluded video: https://www.internalfb.com/phabricator/paste/view/P514064530

Here are the command and result for validating in torchvision on this PR:
```
PYTHONPATH=:/data/home/yosuamichael/repos/vision/references/video_classification \
python -u ~/script/run_with_submitit.py \
    --timeout 3000 --ngpus 8 --nodes 1 \
    --model=omnivore \
    --data-path="/data/home/yosuamichael/datasets/clean_kinetics_400/" \
    --batch-size=16 --test-only \
    --clip-len 32 --frame-rate 16 --clips-per-video 5 \
    --cache-dataset \

# Test: Total time: 0:26:39
# * Clip Acc@1 70.925 Clip Acc@5 88.894
# * Video Acc@1 78.149 Video Acc@5 93.379
```

And here is the result on SlowFast:
```
{"split": "test_final", "top1_acc": "78.66", "top1_acc_clip": "71.67", "top5_acc": "93.64", "top5_acc_clip": "89.04"}
```

We use this config for slowfast: https://www.internalfb.com/phabricator/paste/view/P514048270

We apply the following patch for slowfast: https://www.internalfb.com/phabricator/paste/view/P514049560

And we run slowfast by using the command:
```
python tools/run_net.py --cfg configs/Kinetics/pytorchvideo/omnivore.yaml
```

We notice that there is still a gap of 0.5% between the slowfast and torchvision for omnivore model that although not big, but still quite significant. We still not really sure the root cause of this 0.5% gap and more investigation is needed, however here are what we think might be the cause:
- The implementation of frame_rate 16 on torchvision might differ from slowfast TARGET_FPS=32 and SAMPLING_RATE=2
- Since we hardcode the transform on both slowfast and torchvision, there might be some transform differences
- Some overflow of the final batches might affect the accuracy (this part shouldn't be as big as 0.5%)