### PR TITLE
[DONT MERGE] Getting video accuracy of torchvision video model

### DIFF
--- a/references/video_classification/train.py
+++ b/references/video_classification/train.py
@@ -154,6 +154,7 @@ def main(args):
     valdir = os.path.join(args.data_path, "val")
 
     print("Loading training data")
+    """
     st = time.time()
     cache_path = _get_cache_path(traindir, args)
     transform_train = presets.VideoClassificationPresetTrain(crop_size=(112, 112), resize_size=(128, 171))
@@ -185,6 +186,7 @@ def main(args):
             utils.save_on_master((dataset, traindir), cache_path)
 
     print("Took", time.time() - st)
+    """
 
     print("Loading validation data")
     cache_path = _get_cache_path(valdir, args)
@@ -215,6 +217,7 @@ def main(args):
                 "mp4",
             ),
             output_format="TCHW",
+            num_workers=args.workers,
         )
         if args.cache_dataset:
             print(f"Saving dataset_test to {cache_path}")
@@ -222,12 +225,13 @@ def main(args):
             utils.save_on_master((dataset_test, valdir), cache_path)
 
     print("Creating data loaders")
-    train_sampler = RandomClipSampler(dataset.video_clips, args.clips_per_video)
+    # train_sampler = RandomClipSampler(dataset.video_clips, args.clips_per_video)
     test_sampler = UniformClipSampler(dataset_test.video_clips, args.clips_per_video)
     if args.distributed:
-        train_sampler = DistributedSampler(train_sampler)
+        # train_sampler = DistributedSampler(train_sampler)
         test_sampler = DistributedSampler(test_sampler, shuffle=False)
 
+    """
     data_loader = torch.utils.data.DataLoader(
         dataset,
         batch_size=args.batch_size,
@@ -236,6 +240,7 @@ def main(args):
         pin_memory=True,
         collate_fn=collate_fn,
     )
+    """
 
     data_loader_test = torch.utils.data.DataLoader(
         dataset_test,
@@ -260,6 +265,7 @@ def main(args):
 
     # convert scheduler to be per iteration, not per epoch, for warmup that lasts
     # between different epochs
+    """
     iters_per_epoch = len(data_loader)
     lr_milestones = [iters_per_epoch * (m - args.lr_warmup_epochs) for m in args.lr_milestones]
     main_lr_scheduler = torch.optim.lr_scheduler.MultiStepLR(optimizer, milestones=lr_milestones, gamma=args.lr_gamma)
@@ -285,7 +291,8 @@ def main(args):
         )
     else:
         lr_scheduler = main_lr_scheduler
-
+    
+    """
     model_without_ddp = model
     if args.distributed:
         model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[args.gpu])


### PR DESCRIPTION
This PR is based on https://github.com/pytorch/vision/pull/6241 but we just remove all training data generation and anything that depend on it.

For all the experiment below, we use kinetics-400 dataset with some video excluded (because they can't be decoded by either pyav or torchvision backend). Here is the list of excluded video: https://gist.github.com/YosuaMichael/02533740966be21d0f0a608c9ca8fb87#file-removed_videos-json

## Reproducing MViT Video Accuracy
By using the video classification script on this PR, we can reproduce the MViT accuracy.
Here is the command and result:
```
PYTHONPATH=:/data/home/yosuamichael/repos/vision/references/video_classification \
python -u ~/script/run_with_submitit.py \
    --timeout 3000 --ngpus 8 --nodes 1 \
    --model mvit_v1_b --weights="MViT_V1_B_Weights.DEFAULT" \
    --data-path="/data/home/yosuamichael/datasets/clean_kinetics_400/" \
    --batch-size=16 --test-only \
    --clip-len 16 --frame-rate 8 --clips-per-video 5 \
    --cache-dataset \
    
# result:
# Test: Total time: 1:25:33
# * Clip Acc@1 70.351 Clip Acc@5 88.288
# * Video Acc@1 78.477 Video Acc@5 93.582
```
**Note that we use a cleaned kinetics dataset, we only use video that can be decoded with both pyav and torchvision backend.

This result is very similar with top1_acc that we get from SlowFast:
```
{"split": "test_final", "top1_acc": "78.52", "top1_acc_clip": "70.96", "top5_acc": "93.67", "top5_acc_clip": "88.68"}
```
For slowfast I use [this patch](https://gist.github.com/YosuaMichael/02533740966be21d0f0a608c9ca8fb87#file-slowfast-patch) and using [this config](https://gist.github.com/YosuaMichael/02533740966be21d0f0a608c9ca8fb87#file-mvit_slowfast-yaml). Then we run using the following command:
```
python tools/run_net.py --cfg configs/Kinetics/pytorchvideo/mvit.yaml
```

We can observe that this is similar the accuracy reported for MViT BConv 16x4 in [here](https://github.com/facebookresearch/SlowFast/blob/main/MODEL_ZOO.md).

## Validate similarity of result with SlowFast on Video ResNet model

The video resnet model contains 3 different model: `r2plus1d_18`, `r3d_18`, and `mc3_18`. We will validate all three of them with the following command:
```
PYTHONPATH=:/data/home/yosuamichael/repos/vision/references/video_classification \
python -u ~/script/run_with_submitit.py \
    --timeout 3000 --ngpus 8 --nodes 1 \
    --batch-size=16 --test-only \
    --model ${MODEL_NAME} --weights="${MODEL_WEIGHT}.DEFAULT" \
    --data-path="/data/home/yosuamichael/datasets/clean_kinetics_400/" \
    --clip-len 16 --frame-rate 8 --clips-per-video 5 \
    --cache-dataset \
```

Here are the result: 
```
MODEL_NAME=r2plus1d_18   and  MODEL_WEIGHT=R2Plus1D_18
Test: Total time: 0:15:13 
 * Clip Acc@1 58.449 Clip Acc@5 79.786
 * Video Acc@1 67.473 Video Acc@5 86.363

MODEL_NAME=r3d_18 and MODEL_WEIGHT=R3D_18
Test: Total time: 0:14:48
 * Clip Acc@1 53.209 Clip Acc@5 76.169
 * Video Acc@1 62.893 Video Acc@5 83.771

MODEL_NAME=mc3_18 and MODEL_WEIGHT=MC3_18
Test: Total time: 0:14:47
 * Clip Acc@1 55.646 Clip Acc@5 77.865
 * Video Acc@1 64.491 Video Acc@5 84.770
```

We compare this result with slowfast result:
```
r2plus1d_18:
{"split": "test_final", "top1_acc": "67.47", "top1_acc_clip": "58.69", "top5_acc": "86.07", "top5_acc_clip": "79.91"}

r3d_18:
{"split": "test_final", "top1_acc": "62.59", "top1_acc_clip": "53.27", "top5_acc": "83.58", "top5_acc_clip": "76.26"}

mc3_18:
{"split": "test_final", "top1_acc": "64.39", "top1_acc_clip": "55.85", "top5_acc": "84.87", "top5_acc_clip": "78.26"}
```
To run the slowfast we use this [patch](https://gist.github.com/YosuaMichael/02533740966be21d0f0a608c9ca8fb87#file-slowfast-patch) 
With the following configs:

- [r2plus1d_18 config](https://gist.github.com/YosuaMichael/02533740966be21d0f0a608c9ca8fb87#file-r2plus1d_18_slowfast-yaml)
- [r3d_18 config](https://gist.github.com/YosuaMichael/02533740966be21d0f0a608c9ca8fb87#file-r3d_18_slowfast-yaml)
- [mc3_18 config](https://gist.github.com/YosuaMichael/02533740966be21d0f0a608c9ca8fb87#file-mc3_18_slowfast-yaml)


To run with the following command:
```
python tools/run_net.py --cfg ${PATH_TO_CONFIG_FILE}
```




